### PR TITLE
Adding the ability to skip the check, on demand

### DIFF
--- a/lib/jira/plugin.rb
+++ b/lib/jira/plugin.rb
@@ -33,7 +33,7 @@ module Danger
     #         Option to report if no JIRA issue was found
     #
     # @param [Boolean] skippable
-    #         Option to skip the report if [no-jira] is provided
+    #         Option to skip the report if 'no-jira' is provided on the PR title, description or commits
     #
     # @return [void]
     #
@@ -41,9 +41,7 @@ module Danger
       throw Error("'key' missing - must supply JIRA issue key") if key.nil?
       throw Error("'url' missing - must supply JIRA installation URL") if url.nil?
 
-      return if should_skip_jira?
-
-      
+      return if skippable && should_skip_jira?      
 
       jira_issues = find_jira_issues(
         key: key,

--- a/lib/jira/plugin.rb
+++ b/lib/jira/plugin.rb
@@ -98,8 +98,6 @@ module Danger
       # Consider first occurrence of 'no-jira'
       regexp = Regexp.new('no-jira', true) 
 
-      jira_issues = []
-
       if search_title
         github.pr_title.gsub(regexp) do |match|
           if match.nil? return true

--- a/lib/jira/plugin.rb
+++ b/lib/jira/plugin.rb
@@ -32,11 +32,18 @@ module Danger
     # @param [Boolean] report_missing
     #         Option to report if no JIRA issue was found
     #
+    # @param [Boolean] skippable
+    #         Option to skip the report if [no-jira] is provided
+    #
     # @return [void]
     #
-    def check(key: nil, url: nil, emoji: ":link:", search_title: true, search_commits: false, fail_on_warning: false, report_missing: true)
+    def check(key: nil, url: nil, emoji: ":link:", search_title: true, search_commits: false, fail_on_warning: false, report_missing: true, skippable: true)
       throw Error("'key' missing - must supply JIRA issue key") if key.nil?
       throw Error("'url' missing - must supply JIRA installation URL") if url.nil?
+
+      return if should_skip_jira?
+
+      
 
       jira_issues = find_jira_issues(
         key: key,
@@ -88,6 +95,34 @@ module Danger
       end
       return jira_issues.uniq
     end
+
+    def should_skip_jira(search_title: true, search_commits: false)
+      # Consider first occurrence of 'no-jira'
+      regexp = Regexp.new('no-jira', true) 
+
+      jira_issues = []
+
+      if search_title
+        github.pr_title.gsub(regexp) do |match|
+          if match.nil? return true
+        end
+      end
+
+      if search_commits
+        git.commits.map do |commit|
+          commit.message.gsub(regexp) do |match|
+            if match.nil? return true
+          end
+        end
+      end
+
+      github.pr_body.gsub(regexp) do |match|
+          if match.nil? return true
+        end
+
+      return false
+    end
+
 
     def ensure_url_ends_with_slash(url)
       return "#{url}/" unless url.end_with?("/")

--- a/spec/jira_spec.rb
+++ b/spec/jira_spec.rb
@@ -47,6 +47,15 @@ module Danger
         expect((issues <=> ["WEB-126"]) == 0)
       end
 
+      it "can find no-jira in pr body" do
+        allow(@jira).to receive_message_chain("github.pr_body").and_return("[no-jira] Ticket doesn't need a jira but [WEB-123] WEB-123")
+        result = @jira.should_skip_jira(
+          search_title: false,
+          search_commits: false
+        )
+        expect((result <=> true) == 0)
+      end
+
       it "can remove duplicates" do
         allow(@jira).to receive_message_chain("github.pr_title").and_return("Ticket [WEB-123] and WEB-123")
         issues = @jira.find_jira_issues(key: "WEB")


### PR DESCRIPTION
At Slack, we use Danger and JIRA. This plugin proved to be very useful for our PR practices.
One thing that we found that it always missed was the ability to skip the check, on demand, using the `[no-jira]` annotation on either the PR title or description.

This is our implementation on the Dangerfile currently:
```
skip_jira_title = github.pr_title.include? 'no-jira'
skip_jira_body = github.pr_body.include? 'no-jira'

if !skip_jira_title && !skip_jira_body
    jira.check(
    key: ["IOSAPP"],
    url: "https://jira.tinyspeck.com/browse/",
    fail_on_warning: true
)
end
```

I thought is could be nice to have this feature built-in the actual plugin, so here it is. I hope you think it's useful for you too!
Disclaimer: this code hasn't been yet tested and I'm very green when it comes to ruby, so be nice. I've added a test but not sure how to run it.