### PR TITLE
Remove [no-jira] from searching commits

### DIFF
--- a/lib/jira/gem_version.rb
+++ b/lib/jira/gem_version.rb
@@ -1,3 +1,3 @@
 module Jira
-  VERSION = "0.5.0".freeze
+  VERSION = "0.5.1".freeze
 end

--- a/lib/jira/plugin.rb
+++ b/lib/jira/plugin.rb
@@ -41,7 +41,7 @@ module Danger
       throw Error("'key' missing - must supply JIRA issue key") if key.nil?
       throw Error("'url' missing - must supply JIRA installation URL") if url.nil?
 
-      return if skippable && should_skip_jira?
+      return if skippable && should_skip_jira?(search_title: search_title)
 
       jira_issues = find_jira_issues(
         key: key,
@@ -94,21 +94,13 @@ module Danger
       return jira_issues.uniq
     end
 
-    def should_skip_jira?(search_title: true, search_commits: false)
+    def should_skip_jira?(search_title: true)
       # Consider first occurrence of 'no-jira'
       regexp = Regexp.new("no-jira", true)
 
       if search_title
         github.pr_title.gsub(regexp) do |match|
           return true unless match.empty?
-        end
-      end
-
-      if search_commits
-        git.commits.map do |commit|
-          commit.message.gsub(regexp) do |match|
-            return true unless match.empty?
-          end
         end
       end
 

--- a/spec/jira_spec.rb
+++ b/spec/jira_spec.rb
@@ -49,24 +49,7 @@ module Danger
 
       it "can find no-jira in pr body" do
         allow(@jira).to receive_message_chain("github.pr_body").and_return("[no-jira] Ticket doesn't need a jira but [WEB-123] WEB-123")
-        result = @jira.should_skip_jira?(
-          search_title: false,
-          search_commits: false
-        )
-        expect(result).to be(true)
-      end
-
-      it "can find no-jira in commits" do
-        single_commit = Object.new
-        def single_commit.message
-          "Small text change [no-jira]"
-        end
-        commits = [single_commit]
-        allow(@jira).to receive_message_chain("git.commits").and_return(commits)
-        result = @jira.should_skip_jira?(
-          search_title: false,
-          search_commits: true
-        )
+        result = @jira.should_skip_jira?(search_title: false)
         expect(result).to be(true)
       end
 


### PR DESCRIPTION
Removing ability to disable a JIRA check because there would be no way to revert it with other commits later.

Referencing #12 